### PR TITLE
Feature/build engine class

### DIFF
--- a/sql_connectors/__init__.py
+++ b/sql_connectors/__init__.py
@@ -1,42 +1,5 @@
 # -*- coding: utf-8 -*-
-from .config_util import get_available_envs_factory, get_available_configs
-from .client import get_client_factory
+from .config_builder import BuildFacade
 from ._version import __version__, __version_info__
 
-def setup():
-    """Create get_client and get_available_envs functions for each datasource using
-    the datasource name as the variable names. It also adds them to __all__ so they
-    show up in auto-complete when importing"""
-    global __all__
-
-    configs = get_available_configs()
-
-    __all__ = [config for config, default in configs] + \
-              [config + '_envs' for config, default in configs]
-
-    for config_file, defaults in configs:
-        varname = config_file
-        schema = defaults['default_schema']
-
-        val = """get_client_factory("{0}", "{1}", {2}, {3})
-        """.format(config_file,
-                   defaults['default_env'],
-                   '"{0}"'.format(schema) if schema is not None else schema,
-                   defaults['default_reflect'])
-        exec('{0}={1}'.format(varname, val), globals())
-
-        varname = config_file + '_envs'
-        val = 'get_available_envs_factory("{0}")'.format(config_file)
-        exec('{0}={1}'.format(varname, val), globals())
-
-def teardown():
-    # Delete temp variables so they don't pollute auto-complete in ipython
-    # this is only useful in python 2.7, doesn't seem to matter in python 3
-    for var in ['get_available_envs_factory', 'get_available_configs',
-                'get_client_factory', 'setup', 'teardown']:
-        if var in globals():
-            del globals()[var]
-
-
-setup()
-teardown()
+__all__ = ["BuildFacade"]

--- a/sql_connectors/__init__.py
+++ b/sql_connectors/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from .config_builder import BuildFacade
+from .facade_builder import BuildFacade, full_path, get_available_configs
+from.default_facade import DefaultFacade, default_facade
 from ._version import __version__, __version_info__
 
-__all__ = ["BuildFacade"]
+__all__ = ["BuildFacade", "DefaultFacade", "full_path", "get_available_configs"]

--- a/sql_connectors/client.py
+++ b/sql_connectors/client.py
@@ -16,7 +16,7 @@ from memoized import memoized
 from .util import extend_docs
 from .exceptions import ConfigurationException
 
-from .config_util import full_path, parse_config
+from .config_util import parse_config
 
 
 __all__ = [
@@ -216,27 +216,3 @@ def _parse_table_name(table_name, schema=None):
         parts[-1],  # name
         schema or parts[0] if len(parts) == 2 else None  # schema
     )
-
-
-def get_client_factory(config_file, default_env='default', default_schema=None,
-                       default_reflect=False):
-    """Wrapper function to create a :any:`get_client` function using the given
-    ``config_file`` and setting the given defaults. This should be used in the submodule
-    for each data source.
-
-    :param str config_file: Name of config file without the extension
-    :param str default_env: Set default environment to use (Default value = 'default')
-    :param str default_schema: Set default schema to use  (Default value = None)
-    :param bool default_reflect: Set default for reflect  (Default value = False)
-    """
-    @extend_docs(SqlClient.__init__)
-    def get_client(env=default_env, default_schema=default_schema,
-                   reflect=default_reflect, **kwargs):
-        """Get a :any:`SqlClient` for the specified
-        environment. Defaults are based on what was passed to :any:`get_client_factory`.
-
-        See :any:`SqlClient.__init__` for params:
-        """
-        return SqlClient(config_file, env, default_schema, reflect, **kwargs)
-
-    return memoized(get_client, signature_preserving=True)

--- a/sql_connectors/client.py
+++ b/sql_connectors/client.py
@@ -42,11 +42,11 @@ class SqlClient(Engine):
     configuration.
     """
     @extend_docs(create_engine)
-    def __init__(self, config_file, env='default', default_schema=None,
+    def __init__(self, config, env='default', default_schema=None,
                  reflect=False, **kwargs):
         """Instanciate a :class:`SqlClient` with the given params.
 
-        :param str config_file: Name of config file without the file extension
+        :param dict config: JSON config read in as a dict
         :param str env: Name of the environment within the config file
              (Default value = 'default')
         :param str default_schema: Name of default schema, used by the
@@ -58,7 +58,7 @@ class SqlClient(Engine):
         See :any:`sqlalchemy.create_engine` for ``**kwargs``:
         """
         #: Name of config file without file extension
-        self.config_file = config_file
+        self.config = config
 
         #: Name of environment within the config file
         self.env = env
@@ -97,16 +97,14 @@ class SqlClient(Engine):
             return self.get_table(key)
 
     def _get_url(self):
-        """Returns a SQLAlchemy URL from given env"""
-        path = full_path(str(self.config_file) + '.json')
-
-        try:
-            with open(path) as reader:
-                conf = json.load(reader)
-
-                return parse_config(conf, self.env)
-        except IOError:
-            raise ConfigurationException('Config file not found')
+        """Returns a SQLAlchemy URL from given env
+        
+        Notes
+        -----
+        - Needs to be generalized to not rely on file
+        - Easiest fix: to add `mode` variable to **kwargs
+        """
+        return parse_config(self.config, self.env)
 
     @property
     def default_schema(self):

--- a/sql_connectors/config_builder.py
+++ b/sql_connectors/config_builder.py
@@ -151,6 +151,16 @@ class BuildFacade(object):
         return instance
 
 
+def get_fname(fpath):
+    return fpath.split("/")[-1].replace(".json", "")
+
+def get_default_params(config_path=None):
+    configs = glob(full_path("*json", config_path))
+    names = [get_fname(i) for i in configs]
+    return tuple({"name":name} for name in names)
+
 def default_facade(**kwargs):
-    cls = BuildFacade(**kwargs)
+    config_path = kwargs.get("config_path", None)
+    params = get_default_params(config_path)
+    cls = BuildFacade(params)
     return cls.build_factory_facade()

--- a/sql_connectors/config_builder.py
+++ b/sql_connectors/config_builder.py
@@ -1,0 +1,42 @@
+from builtins import super
+from argparse import Namespace
+
+
+class ParseJSON(object):
+    def __init__(self, **kwargs):
+        return
+
+    def parse(self, **kwargs):
+        return
+
+
+class ParseConfig(ParseJSON):
+    def __init__(self, **kwargs):
+        return
+
+    def _read_file(self):
+        return
+
+    def _read_redis(self):
+        return
+
+    def parse(self, method="file"):
+        return
+
+
+class BuildFacade(ParseConfig):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build_config_kwargs(self):
+        return
+
+    def build_facade(self):
+        kwargs = self.build_config_kwargs()
+        instance = Namespace(**kwargs)
+        return instance
+
+
+def default_facade(**kwargs):
+    cls = BuildFacade(**kwargs)
+    return cls.build_facade()

--- a/sql_connectors/config_builder.py
+++ b/sql_connectors/config_builder.py
@@ -2,6 +2,9 @@ import os
 from argparse import Namespace
 from builtins import super
 from glob import glob
+from memoized import memoized
+from .util import extend_docs
+import json
 
 from six import iteritems
 
@@ -10,6 +13,7 @@ from .config_util import full_path, get_available_configs, get_available_envs_fa
 from .exceptions import ConfigurationException
 
 DEFAULT_CONFIG_DIR = "~/.config/sql_connectors"
+
 CONFIG_DEFAULTS = {
     "default_env": "default",
     "default_schema": None,
@@ -34,14 +38,24 @@ def merge_dicts(*args):
     return res_dict
 
 
-def read_json(fname):
+def read_json(fpath):
     try:
-        with open(path) as reader:
-            conf = json.load(reader)
-
-            return parse_config(conf, self.env)
+        with open(fpath) as reader:
+            config = json.load(reader)
+            return config
     except IOError:
         raise ConfigurationException("Config file not found")
+
+
+def full_path(sub_path="", default_config_dir=DEFAULT_CONFIG_DIR):
+    """Turn a path relative to the config base dir into a full path
+
+    :param str sub_path: Subpath relative to the config base dir
+    """
+    config_base_dir = os.environ.get('SQL_CONNECTORS_CONFIG_DIR',
+                                     default_config_dir)
+
+    return os.path.join(os.path.expanduser(config_base_dir), sub_path)
 
 
 def get_available_configs(fpath):
@@ -50,14 +64,15 @@ def get_available_configs(fpath):
 
 
 class ParseConfig(object):
-    def __init__(self, fname, config_dict=None):
+    def __init__(self, fname, config_dict=None, config_path=None):
         self.fname = fname
-        self.config = None
+        self.config = config_dict
+        self.config_path = config_path
 
     @staticmethod
-    def read_config_file(fname):
+    def read_config_file(fname, config_path=None):
         if isinstance(fname, str):
-            fpath = full_path(fname + ".json")
+            fpath = full_path(fname + ".json", config_path)
             config = read_json(fpath)
         else:
             raise ConfigurationException(
@@ -67,27 +82,24 @@ class ParseConfig(object):
 
     @staticmethod
     def get_config_defaults(config, defaults=CONFIG_DEFAULTS):
-        for key in ["default_env", "default_schema", "default_reflect"]:
-            assert key in config.keys(), "{0} must be in your config defaults dict - "
-        return dict((k, config.get(k, defaults[k])) for k in defaults)
+        return dict((k, config.get(k, defaults[k])) for k in defaults.keys())
 
     @staticmethod
-    def get_client_factory_kwargs(fname, defaults=CONFIG_DEFAULTS, config_dict=None):
+    def get_client_factory_kwargs(fname, defaults=CONFIG_DEFAULTS, config_dict=None, config_path=None):
         if config_dict:
             config = config_dict
         else:
-            config = ParseConfigs.read_config_file(fname)
-        config_defaults = ParseConfigs.get_config_defaults(config, defaults)
+            config = ParseConfig.read_config_file(fname, config_path)
+        config_defaults = ParseConfig.get_config_defaults(config, defaults)
         kwargs = merge_dicts({"config": config}, config_defaults)
         return kwargs
 
-    @staticmethod
     @extend_docs(SqlClient.__init__)
+    @staticmethod
     def get_client_factory(**kwargs):
         for key in ["config", "default_env", "default_schema", "default_reflect"]:
-            assert kwargs.get(key, None), "{0} must be a kwarg"
+            assert key in kwargs.keys(), "{0} must be a kwarg".format(key)
         NS = Namespace(**kwargs)
-
         def get_client(
             env=NS.default_env,
             default_schema=NS.default_schema,
@@ -96,17 +108,17 @@ class ParseConfig(object):
         ):
             return SqlClient(NS.config, env, default_schema, reflect, **kwargs)
 
-    return memoized(get_client, signature_preserving=True)
+        return memoized(get_client, signature_preserving=True)
 
     def get_available_envs(self, non_env_keys=NON_ENV_KEYS):
         if not self.config:
-            self.config = self.read_config_file(self.fname)
+            self.config = self.read_config_file(self.fname, self.config_path)
         keys = list(self.config.keys())
         return [i for i in keys if i not in non_env_keys]
 
     def get_factory_dict(self):
         if not self.config:
-            self.config = self.read_config_file(self.fname)
+            self.config = self.read_config_file(self.fname, self.config_path)
         factory_kwargs = self.get_client_factory_kwargs(
             self.fname, config_dict=self.config
         )
@@ -115,25 +127,26 @@ class ParseConfig(object):
 
 
 class BuildFacade(object):
-    def __init__(self, config_param_dict, mode="file", **kwargs):
+    def __init__(self, config_params, mode="file", **kwargs):
         # Need another class to dynamically generate "config params" for file vs redis
         assert mode in [
             "file",
             "redis",
         ], "Invalid config parsing mode {0} specified".format(mode)
-        self.config_param_dict = config_param_dict
+        self.config_params = config_params
+        self.config_path = kwargs.get("config_path", None)
 
     def get_factories(self):
         factory_args = []
-        for params in self.config_param_dict:
+        for params in self.config_params:
             name = params["name"]
             config = params.get("config_dict", None)
-            parser = ParseConfig(name, config)
-            factory_args.append(factory_dict)
+            parser = ParseConfig(name, config, self.config_path)
+            factory_args.append(parser.get_factory_dict())
         return merge_dicts(*factory_args)
 
     def build_factory_facade(self):
-        kwargs = self.get_factories
+        kwargs = self.get_factories()
         instance = Namespace(**kwargs)
         return instance
 

--- a/sql_connectors/config_builder.py
+++ b/sql_connectors/config_builder.py
@@ -1,20 +1,39 @@
 from builtins import super
 from argparse import Namespace
+from six import iteritems
+
+from .config_util import get_available_envs_factory, get_available_configs
+from .client import get_client_factory
 
 
-class ParseJSON(object):
-    def __init__(self, **kwargs):
-        return
+def merge_dicts(*args):
+    # should raise warning for duplicate keys
+    res_dict = {}
+    for d in args:
+        for k,v in iteritems(d):
+            res_dict[k] = v
+    return res_dict
 
-    def parse(self, **kwargs):
-        return
+def parse_config_entry(config_entry):
+    fname, defaults = config_entry
+    env = defaults.gets("default_env", None)
+    schema = defaults.get("default_schema", "default")
+    reflect = defaults.get("default_reflect", False)
+
+    client_factory = get_client_factory(env, schema, reflect)
+    env_factory = get_available_envs_factory("fname")
+
+    parsed_kwarg = {fname: client_factory,
+                    fname+"_envs": env_factory}
+    return parsed_kwarg
 
 
-class ParseConfig(ParseJSON):
+class ParseConfig(object):
     def __init__(self, **kwargs):
         return
 
     def _read_file(self):
+
         return
 
     def _read_redis(self):

--- a/sql_connectors/config_builder.py
+++ b/sql_connectors/config_builder.py
@@ -1,61 +1,143 @@
-from builtins import super
+import os
 from argparse import Namespace
+from builtins import super
+from glob import glob
+
 from six import iteritems
 
-from .config_util import get_available_envs_factory, get_available_configs
-from .client import get_client_factory
+from .client import SqlClient, get_client_factory
+from .config_util import full_path, get_available_configs, get_available_envs_factory
+from .exceptions import ConfigurationException
+
+DEFAULT_CONFIG_DIR = "~/.config/sql_connectors"
+CONFIG_DEFAULTS = {
+    "default_env": "default",
+    "default_schema": None,
+    "default_reflect": False,
+}
+NON_ENV_KEYS = [
+    "drivername",
+    "relative_paths",
+    "allowed_hosts",
+    "default_env",
+    "default_schema",
+    "default_reflect",
+]
 
 
 def merge_dicts(*args):
     # should raise warning for duplicate keys
     res_dict = {}
     for d in args:
-        for k,v in iteritems(d):
+        for k, v in iteritems(d):
             res_dict[k] = v
     return res_dict
 
-def parse_config_entry(config_entry):
-    fname, defaults = config_entry
-    env = defaults.gets("default_env", None)
-    schema = defaults.get("default_schema", "default")
-    reflect = defaults.get("default_reflect", False)
 
-    client_factory = get_client_factory(env, schema, reflect)
-    env_factory = get_available_envs_factory("fname")
+def read_json(fname):
+    try:
+        with open(path) as reader:
+            conf = json.load(reader)
 
-    parsed_kwarg = {fname: client_factory,
-                    fname+"_envs": env_factory}
-    return parsed_kwarg
+            return parse_config(conf, self.env)
+    except IOError:
+        raise ConfigurationException("Config file not found")
+
+
+def get_available_configs(fpath):
+    files = glob(os.path.join(fpath, "*.json"))
+    return files
 
 
 class ParseConfig(object):
-    def __init__(self, **kwargs):
-        return
+    def __init__(self, fname, config_dict=None):
+        self.fname = fname
+        self.config = None
 
-    def _read_file(self):
+    @staticmethod
+    def read_config_file(fname):
+        if isinstance(fname, str):
+            fpath = full_path(fname + ".json")
+            config = read_json(fpath)
+        else:
+            raise ConfigurationException(
+                "Invalid config object - must be filename (no extension)"
+            )
+        return config
 
-        return
+    @staticmethod
+    def get_config_defaults(config, defaults=CONFIG_DEFAULTS):
+        for key in ["default_env", "default_schema", "default_reflect"]:
+            assert key in config.keys(), "{0} must be in your config defaults dict - "
+        return dict((k, config.get(k, defaults[k])) for k in defaults)
 
-    def _read_redis(self):
-        return
+    @staticmethod
+    def get_client_factory_kwargs(fname, defaults=CONFIG_DEFAULTS, config_dict=None):
+        if config_dict:
+            config = config_dict
+        else:
+            config = ParseConfigs.read_config_file(fname)
+        config_defaults = ParseConfigs.get_config_defaults(config, defaults)
+        kwargs = merge_dicts({"config": config}, config_defaults)
+        return kwargs
 
-    def parse(self, method="file"):
-        return
+    @staticmethod
+    @extend_docs(SqlClient.__init__)
+    def get_client_factory(**kwargs):
+        for key in ["config", "default_env", "default_schema", "default_reflect"]:
+            assert kwargs.get(key, None), "{0} must be a kwarg"
+        NS = Namespace(**kwargs)
+
+        def get_client(
+            env=NS.default_env,
+            default_schema=NS.default_schema,
+            reflect=NS.default_reflect,
+            **kwargs
+        ):
+            return SqlClient(NS.config, env, default_schema, reflect, **kwargs)
+
+    return memoized(get_client, signature_preserving=True)
+
+    def get_available_envs(self, non_env_keys=NON_ENV_KEYS):
+        if not self.config:
+            self.config = self.read_config_file(self.fname)
+        keys = list(self.config.keys())
+        return [i for i in keys if i not in non_env_keys]
+
+    def get_factory_dict(self):
+        if not self.config:
+            self.config = self.read_config_file(self.fname)
+        factory_kwargs = self.get_client_factory_kwargs(
+            self.fname, config_dict=self.config
+        )
+        factory = self.get_client_factory(**factory_kwargs)
+        return {self.fname: factory, self.fname + "_envs": self.get_available_envs()}
 
 
-class BuildFacade(ParseConfig):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+class BuildFacade(object):
+    def __init__(self, config_param_dict, mode="file", **kwargs):
+        # Need another class to dynamically generate "config params" for file vs redis
+        assert mode in [
+            "file",
+            "redis",
+        ], "Invalid config parsing mode {0} specified".format(mode)
+        self.config_param_dict = config_param_dict
 
-    def build_config_kwargs(self):
-        return
+    def get_factories(self):
+        factory_args = []
+        for params in self.config_param_dict:
+            name = params["name"]
+            config = params.get("config_dict", None)
+            parser = ParseConfig(name, config)
+            factory_args.append(factory_dict)
+        return merge_dicts(*factory_args)
 
-    def build_facade(self):
-        kwargs = self.build_config_kwargs()
+    def build_factory_facade(self):
+        kwargs = self.get_factories
         instance = Namespace(**kwargs)
         return instance
 
 
 def default_facade(**kwargs):
     cls = BuildFacade(**kwargs)
-    return cls.build_facade()
+    return cls.build_factory_facade()

--- a/sql_connectors/config_builder.py
+++ b/sql_connectors/config_builder.py
@@ -1,16 +1,16 @@
+import json
 import os
 from argparse import Namespace
 from builtins import super
 from glob import glob
-from memoized import memoized
-from .util import extend_docs
-import json
 
+from memoized import memoized
 from six import iteritems
 
-from .client import SqlClient, get_client_factory
-from .config_util import full_path, get_available_configs, get_available_envs_factory
+from .client import SqlClient
+from .config_util import full_path
 from .exceptions import ConfigurationException
+from .util import extend_docs
 
 DEFAULT_CONFIG_DIR = "~/.config/sql_connectors"
 
@@ -52,8 +52,7 @@ def full_path(sub_path="", default_config_dir=DEFAULT_CONFIG_DIR):
 
     :param str sub_path: Subpath relative to the config base dir
     """
-    config_base_dir = os.environ.get('SQL_CONNECTORS_CONFIG_DIR',
-                                     default_config_dir)
+    config_base_dir = os.environ.get("SQL_CONNECTORS_CONFIG_DIR", default_config_dir)
 
     return os.path.join(os.path.expanduser(config_base_dir), sub_path)
 
@@ -85,7 +84,9 @@ class ParseConfig(object):
         return dict((k, config.get(k, defaults[k])) for k in defaults.keys())
 
     @staticmethod
-    def get_client_factory_kwargs(fname, defaults=CONFIG_DEFAULTS, config_dict=None, config_path=None):
+    def get_client_factory_kwargs(
+        fname, defaults=CONFIG_DEFAULTS, config_dict=None, config_path=None
+    ):
         if config_dict:
             config = config_dict
         else:
@@ -100,6 +101,7 @@ class ParseConfig(object):
         for key in ["config", "default_env", "default_schema", "default_reflect"]:
             assert key in kwargs.keys(), "{0} must be a kwarg".format(key)
         NS = Namespace(**kwargs)
+
         def get_client(
             env=NS.default_env,
             default_schema=NS.default_schema,
@@ -154,10 +156,12 @@ class BuildFacade(object):
 def get_fname(fpath):
     return fpath.split("/")[-1].replace(".json", "")
 
+
 def get_default_params(config_path=None):
     configs = glob(full_path("*json", config_path))
     names = [get_fname(i) for i in configs]
-    return tuple({"name":name} for name in names)
+    return tuple({"name": name} for name in names)
+
 
 def default_facade(**kwargs):
     config_path = kwargs.get("config_path", None)

--- a/sql_connectors/config_util.py
+++ b/sql_connectors/config_util.py
@@ -6,6 +6,7 @@ from getpass import getpass
 import os
 import json
 from glob import glob
+from warnings import warn
 
 from sqlalchemy.engine.url import URL
 
@@ -21,18 +22,23 @@ __all__ = [
 ]
 
 DEFAULT_CONFIG_DIR = "~/.config/sql_connectors"
+CONFIG_DEFAULTS = {
+        'default_env': 'default',
+        'default_schema': None,
+        'default_reflect': False
+    }
 
 def parse_config(conf, env):
     """Get the specific environment, expand any relative paths, and return
     a url for create_engine
 
-    :param str conf: Name of config file without the file extension
+    :param dict conf: Name of config file without the file extension
     :param str env: Name of the environment within the config file
     """
-    if env not in conf:
+    if env not in conf.keys():
         raise ConfigurationException('Env does not exist in config file')
 
-    if 'drivername' not in conf:
+    if 'drivername' not in conf.keys():
         raise ConfigurationException('Missing drivername')
 
     drivername = conf['drivername']
@@ -74,17 +80,13 @@ def get_available_configs():
             for f in files]
 
 
-def _get_config_defaults(path):
+def _get_config_defaults(path, defaults=CONFIG_DEFAULTS):
     """Return the default_env, default_schema, and default_reflect from a
     config file.
 
     :param str path: Path for config file
+    :param dict defaults: Dict of default config
     """
-    defaults = {
-        'default_env': 'default',
-        'default_schema': None,
-        'default_reflect': False
-    }
     try:
         with open(path) as reader:
             conf = json.load(reader)

--- a/sql_connectors/config_util.py
+++ b/sql_connectors/config_util.py
@@ -54,7 +54,7 @@ def parse_config(conf, env):
     return URL(**env_conf)
 
 
-def full_path(sub_path):
+def full_path(sub_path=""):
     """Turn a path relative to the config base dir into a full path
 
     :param str sub_path: Subpath relative to the config base dir

--- a/sql_connectors/config_util.py
+++ b/sql_connectors/config_util.py
@@ -16,7 +16,6 @@ __all__ = [
     'parse_config',
     'full_path',
     'get_available_configs',
-    'get_available_envs_factory',
     'get_key_value',
     'set_key_value'
 ]
@@ -95,26 +94,6 @@ def _get_config_defaults(path, defaults=CONFIG_DEFAULTS):
         raise ConfigurationException('Config file not found')
     except:
         raise ConfigurationException('Error reading {0}'.format(path))
-
-
-def get_available_envs_factory(config_file):
-    """Create a :any:`get_available_envs` function for the given config
-    file.
-
-    :param str config_file: Name of config file without the file extension
-    """
-    def get_available_envs():
-        """Return available environments in config file"""
-        path = full_path(str(config_file) + '.json')
-        try:
-            with open(path) as reader:
-                keys = list(json.load(reader))
-                non_envs = ['drivername', 'relative_paths', 'allowed_hosts',
-                            'default_env', 'default_schema', 'default_reflect']
-                return [key for key in keys if key not in non_envs]
-        except IOError:
-            raise ConfigurationException('Config file not found')
-    return get_available_envs
 
 
 def _get_username(conf):

--- a/sql_connectors/default_facade.py
+++ b/sql_connectors/default_facade.py
@@ -1,0 +1,55 @@
+from glob import glob
+from .facade_builder import BuildFacade, full_path
+
+def get_fname(fpath):
+    """Gets filename without extension from full path
+    
+    Parameters
+    ----------
+    fpath : str
+        full path
+    
+    Returns
+    -------
+    str
+    """
+    return fpath.split("/")[-1].replace(".json", "")
+
+
+def get_default_params(config_path=None):
+    """Gets default params from a config location on disk
+    
+    Parameters
+    ----------
+    config_path : str, optional
+        config location on disk - defaults to the SQL_CONNECTORS_CONFIG_DIR environment var
+    
+    Returns
+    -------
+    tuple of dicts
+        iterable of config file names to pass into `BuildFacade`
+    """
+    configs = glob(full_path("*json", config_dir = config_path))
+    names = [get_fname(i) for i in configs]
+    return tuple({"name": name} for name in names)
+
+
+def default_facade(**kwargs):
+    """Function to build out the connector facade from the default config path
+
+    Parameters
+    ----------
+    **kwargs
+    config_path: str
+        location of config file - defaults to the SQL_CONNECTORS_CONFIG_DIR environment var
+
+    Returns
+    -------
+    argparse.Namespace
+    """
+    config_path = kwargs.get("config_path", None)
+    params = get_default_params(config_path)
+    cls = BuildFacade(params)
+    return cls.build_factory_facade()
+
+DefaultFacade = default_facade()

--- a/sql_connectors/facade_builder.py
+++ b/sql_connectors/facade_builder.py
@@ -102,7 +102,7 @@ def full_path(sub_path="", config_dir=None, default_config_dir=DEFAULT_CONFIG_DI
     return os.path.join(os.path.expanduser(config_base_dir), sub_path)
 
 
-def get_available_configs(fpath):
+def get_available_configs(fpath=None):
     """Gets all available json configs in a certain path
     
     Parameters
@@ -115,6 +115,8 @@ def get_available_configs(fpath):
     list of str
         list of json full file paths
     """
+    if fpath is None:
+        fpath = full_path()
     files = glob(os.path.join(fpath, "*.json"))
     return files
 
@@ -340,55 +342,3 @@ class BuildFacade(object):
         kwargs = self.get_factories()
         instance = Namespace(**kwargs)
         return instance
-
-
-def get_fname(fpath):
-    """Gets filename without extension from full path
-    
-    Parameters
-    ----------
-    fpath : str
-        full path
-    
-    Returns
-    -------
-    str
-    """
-    return fpath.split("/")[-1].replace(".json", "")
-
-
-def get_default_params(config_path=None):
-    """Gets default params from a config location on disk
-    
-    Parameters
-    ----------
-    config_path : str, optional
-        config location on disk - defaults to the SQL_CONNECTORS_CONFIG_DIR environment var
-    
-    Returns
-    -------
-    tuple of dicts
-        iterable of config file names to pass into `BuildFacade`
-    """
-    configs = glob(full_path("*json", config_dir = config_path))
-    names = [get_fname(i) for i in configs]
-    return tuple({"name": name} for name in names)
-
-
-def default_facade(**kwargs):
-    """Function to build out the connector facade from the default config path
-
-    Parameters
-    ----------
-    **kwargs
-    config_path: str
-        location of config file - defaults to the SQL_CONNECTORS_CONFIG_DIR environment var
-
-    Returns
-    -------
-    argparse.Namespace
-    """
-    config_path = kwargs.get("config_path", None)
-    params = get_default_params(config_path)
-    cls = BuildFacade(params)
-    return cls.build_factory_facade()


### PR DESCRIPTION
The main purpose of this PR is to make the `sql_connectors` module a little more flexible in general by decoupling the full factory generation from the \_\_init__, and giving the user more options in setting up where the configs are parsed from

This allows for
- Easier troubleshooting if the path variable gets overridden or is not properly set
- Easy to manually set a path to generate connections from
- Easy for end users to code custom functionality to parse configs using a method other than from disk (i.e pull configs from an external source like `redis`)

New Usage
------------
```
from sql_connectors import BuildFacade
```

Building an engine Facade requires passing an tuple of dicts into the `BuildFacade` class. You can choose to reference a local file of a specific name

```
config_params = ({"name":"postgres})
```

Or you can choose to pass in a dict directly and manually the name of the engine factory that will be bound to the engine facade

```
config_params = ({"name":"postgres", "config_dict":{}})
```

After creating the config param tuple, you just initialize `BuildFacade` with the params as an arg and run `build_factory_facade` to return a argparse `NameSpace` object with all of the config engine factories bound to it.

```
builder = BuildFacade(config_params, config_path=None)
connectors = builder.build_factory_facade()
engine = connectors.postgres()
```

I also set it up so you can easily just import a `DefaultFacade` , which just exactly mimics the behavior of the old module where config files are read from $SQL_CONNECTORS_CONFIG_DIR

```
from sql_connectors import DefaultFacade
engine = DefaultFacade.postgres()
```